### PR TITLE
Update imoguizmo.hpp to include cstdint

### DIFF
--- a/imoguizmo.hpp
+++ b/imoguizmo.hpp
@@ -28,6 +28,7 @@ SOFTWARE.
 #include <cstring>
 #include <vector>
 #include <algorithm>
+#include <cstdint>
 
 namespace ImOGuizmo {
 	namespace internal {


### PR DESCRIPTION
Some platforms will not have `uint32_t` available via any of the other headers, so it should be manually included there.